### PR TITLE
Adjust amount inflation

### DIFF
--- a/supermdat_general_exploration/Code/VariableCleaning/NewAnalyses/10_NB_Clean_Dates.Rmd
+++ b/supermdat_general_exploration/Code/VariableCleaning/NewAnalyses/10_NB_Clean_Dates.Rmd
@@ -1,0 +1,246 @@
+---
+title: "R Notebook for Exploration of US House Expenditures: 'purpose' variable"
+output: html_notebook
+---
+  
+    
+  This is an [R Markdown](http://rmarkdown.rstudio.com) Notebook for exploration of US House Expenditures. Data were obtained from the ProPublica website here:  
+[ProPublica](https://projects.propublica.org/represent/expenditures)  
+  
+  
+  The code below is for cleaning date variables. This clean-up uses `SpellingAdjust_Payee` as the base dataset to begin the work. `SpellingAdjust_Payee` was created in the previous clean-up R Notebook `9_NB_CleanChrVar_Payee.Rmd`.
+  
+    
+    Setup the root directory.
+```{r "setup", include = FALSE}
+
+require("knitr")
+
+opts_knit$set(root.dir = "/Users/mdturse/Desktop/Analytics/house_expenditures/supermdat_general_exploration")
+
+```
+  
+    
+    Set "wd" as the working directory.
+```{r}
+
+wd <- getwd()
+wd
+
+```
+  
+    
+    Load the packages to be used.
+```{r, message=FALSE, warning=FALSE}
+
+library("tidyverse")          # data manipulation
+library("lubridate")          # date manipulation
+
+```
+  
+    
+    Session Info.
+```{r}
+
+sessionInfo()
+
+```
+  
+    
+    First, we'll just load in the dataset and do a quick inspection.
+```{r}
+
+SpellingAdjust_Payee <- readRDS(paste0(wd,
+                                       "/ProcessedData/",
+                                       "SpellingAdjust_Payee.Rds"
+                                       )
+                                )
+
+
+message("SpellingAdjust_Payee")
+dim(SpellingAdjust_Payee)
+str(SpellingAdjust_Payee)
+summary(SpellingAdjust_Payee)
+
+```
+  
+    
+    Now realizing that the `date_clean_ymd` needs some manipulation as it has 352,962 values that are NA. We can probably use `start_date` as it has only 8 values that are NA, but this first needs to be cleaned as the extreme dates (e.g. 2061-06-01) make it appear that this is a manually typed value.
+```{r}
+
+date_vars <- c("date_clean_ymd",
+               "date_yr",
+               "date_mth",
+               "date_day",
+               "year_clean",
+               "quarter_clean",
+               "start_date"
+               )
+
+select(SpellingAdjust_Payee,
+       date_vars
+       ) %>%
+  head(500)
+
+
+
+message("JustDateVars")
+select(SpellingAdjust_Payee,
+       date_vars
+       ) %>% 
+  summary()
+
+```
+  
+    
+    Inspecting if we can really use `start_date` to fill in for `date_clean_ymd` when `date_clean_ymd` is NA.  
+      
+      Looks to be ok to use as the basic summary statistics and a visual inspection of the density plot look to be very close.
+```{r}
+
+DatesAll <- select(SpellingAdjust_Payee,
+                   start_date
+                   ) %>% 
+  mutate(type = "DatesAll")
+
+DatesNA <- filter(SpellingAdjust_Payee,
+                  is.na(date_clean_ymd)
+                  ) %>% 
+  select(start_date) %>% 
+  mutate(type = "DatesNA")
+
+
+DateToPlot <- rbind(DatesAll, DatesNA)
+
+rm(DatesAll, DatesNA)
+str(DateToPlot)
+
+
+message("DatesAll")
+filter(DateToPlot,
+       type == "DatesAll"
+       ) %>% 
+  select(start_date) %>% 
+  summary()
+
+message("DatesNA")
+filter(DateToPlot,
+       type == "DatesNA"
+       ) %>% 
+  select(start_date) %>% 
+  summary()
+
+
+DatesAllQuantile <- as.Date(quantile(as.numeric(filter(DateToPlot,
+                                   type == "DatesAll"
+                                   )$start_date
+                            ),
+                            probs = seq(0, 1, 0.1),
+                            type = 1,
+                            na.rm = TRUE
+                            ),
+                            origin = "1970-01-01"
+                            )
+
+DatesNAQuantile <- 
+  as.Date(quantile(as.numeric(filter(DateToPlot,
+                                     type == "DatesNA"
+                                     )$start_date
+                              ),
+                   probs = seq(0, 1, 0.1),
+                   type = 1,
+                   na.rm = TRUE
+                   ),
+          origin = "1970-01-01"
+          )
+
+QuantileCompare <- cbind(DatesAllQuantile, DatesNAQuantile) %>% 
+  as.data.frame() %>% 
+  rownames_to_column(var = "QuantileLevel") %>% 
+  mutate_at(vars(DatesAllQuantile, DatesNAQuantile),
+            funs(d2 = as.Date(.,
+                              origin = "1970-01-01")
+                 )
+            ) %>% 
+  select(-DatesAllQuantile,
+         -DatesNAQuantile
+         )
+
+QuantileCompare
+View(QuantileCompare)
+
+rm(DatesAllQuantile, DatesNAQuantile)
+
+
+ggplot(DateToPlot,
+       aes(x = start_date,
+           # y = ..density..,
+           fill = type
+           )
+       ) +
+  geom_density(alpha = 0.25, na.rm = TRUE) +
+  coord_cartesian(xlim = c(as.Date("2010-01-01"), as.Date("2016-12-31")
+                           )
+                  ) +
+  labs(title = "Density Comparision of start_date",
+       subtitle = "Data (all) vs. Data (when date_clean_ymd is NA)") +
+  theme_minimal()
+
+```
+  
+    
+    So now let's update `date_clean_ymd` with `start_date`.
+```{r}
+
+message("SpellingAdjust_Payee")
+str(SpellingAdjust_Payee)
+
+DateClean <- SpellingAdjust_Payee %>% 
+  mutate(date_clean_ymd_CLEAN = ifelse(is.na(date_clean_ymd),
+                                       start_date,
+                                       date_clean_ymd
+                                       ) %>% 
+           as.Date(origin = "1970-01-01"),
+         date_yr_CLEAN = ifelse(is.na(date_yr),
+                                year(date_clean_ymd_CLEAN),
+                                date_yr
+                                ) %>% 
+           as.integer(),
+         date_mth_CLEAN = ifelse(is.na(date_mth),
+                                 month(date_clean_ymd_CLEAN,
+                                       label = FALSE
+                                       ),
+                                 date_mth
+                                 ) %>% 
+           as.integer(),
+         date_day_CLEAN = ifelse(is.na(date_day),
+                                day(date_clean_ymd_CLEAN),
+                                date_day
+                                ) %>% 
+           as.integer()
+         )
+
+
+message("DateClean")
+select(DateClean,
+       matches("date")
+       ) %>% 
+  str()
+
+message("DateClean")
+select(DateClean,
+       matches("date")
+       ) %>% 
+  summary()
+
+```
+  
+    
+    Remove unneeded files.
+```{r}
+
+rm(SpellingAdjust_Payee, DateToPlot, date_vars, QuantileCompare)
+
+```
+
+

--- a/supermdat_general_exploration/Code/VariableCleaning/NewAnalyses/11_NB_Adjust_Amount_Inflation.Rmd
+++ b/supermdat_general_exploration/Code/VariableCleaning/NewAnalyses/11_NB_Adjust_Amount_Inflation.Rmd
@@ -1,0 +1,280 @@
+---
+title: "R Notebook for Exploration of US House Expenditures: 'purpose' variable"
+output: html_notebook
+---
+  
+    
+  This is an [R Markdown](http://rmarkdown.rstudio.com) Notebook for exploration of US House Expenditures. Data were obtained from the ProPublica website here:  
+[ProPublica](https://projects.propublica.org/represent/expenditures)  
+  
+  
+  The code below is for adjusting the value in the `amount` variable for inflation. This clean-up uses `DateClean` as the base dataset to begin the work. `DateClean` was created in the previous clean-up R Notebook `10_NB_Clean_Dates.Rmd`.  
+    
+    
+    Setup the root directory.
+```{r "setup", include = FALSE}
+
+require("knitr")
+
+opts_knit$set(root.dir = "/Users/mdturse/Desktop/Analytics/house_expenditures/supermdat_general_exploration")
+
+```
+  
+    
+    Set "wd" as the working directory.
+```{r}
+
+wd <- getwd()
+wd
+
+```
+  
+    
+    Load the packages to be used.
+```{r, message=FALSE, warning=FALSE}
+
+library("tidyverse")          # data manipulation
+library("magrittr")           # data manipulation (piping data)
+library("blsAPI")             # easily get data from the BLS API
+library("rjson")              # needed to parse the data from the BLS API
+
+```
+  
+    
+    Session Info.
+```{r}
+
+sessionInfo()
+
+```
+  
+    
+    First, we'll just load in the dataset and do a quick inspection.
+```{r}
+
+DateClean <- readRDS(paste0(wd,
+                            "/ProcessedData/",
+                            "DateClean.Rds"
+                            )
+                     )
+
+
+message("DateClean")
+dim(DateClean)
+str(DateClean)
+summary(DateClean)
+
+```
+  
+    
+    Basically, the only numeric variable is `amount`. All the others are character or factor, and as those were largely "cleaned up" previously, we'll focus primarily on `amount` here.  
+      
+      First, let's just get the variables we're interested in.
+```{r}
+
+
+message("DateClean")
+str(DateClean)
+
+
+DateClean_SelectedVars <- 
+  select(DateClean,
+         RowNum,
+         date_clean_ymd_CLEAN,
+         date_yr_CLEAN,
+         date_mth_CLEAN,
+         date_day_CLEAN,
+         year_clean,
+         quarter_clean,
+         # date_mth,
+         # date_day,
+         start_date,
+         end_date,
+         
+         transcodelong,
+         transcodelong_factor, # 3 levels
+         category,
+         category_factor,     # 12 levels
+         office_cc,
+         office_cc_factor,    # 827 levels
+         program_cc,
+         program_cc_factor,   # 95 levels
+         purpose_cc,
+         purpose_cc_factor,   # 6,623 levels
+         
+         amount
+         ) %>% 
+  mutate(date_YrMth = factor(paste(date_yr_CLEAN,
+                                   date_mth_CLEAN,
+                                   sep = "-"
+                                   ),
+                             levels = c("2006-1", "2006-2","2006-3","2006-4",
+                                        "2006-5", "2006-6","2006-7","2006-8",
+                                        "2006-9", "2006-10","2006-11","2006-12",
+                                        "2007-1", "2007-2","2007-3","2007-4",
+                                        "2007-5", "2007-6","2007-7","2007-8",
+                                        "2007-9", "2007-10","2007-11","2007-12",
+                                        "2008-1", "2008-2","2008-3","2008-4",
+                                        "2008-5", "2008-6","2008-7","2008-8",
+                                        "2008-9", "2008-10","2008-11","2008-12",
+                                        "2009-1", "2009-2","2009-3","2009-4",
+                                        "2009-5", "2009-6","2009-7","2009-8",
+                                        "2009-9", "2009-10","2009-11","2009-12",
+                                        "2010-1", "2010-2","2010-3","2010-4",
+                                        "2010-5", "2010-6","2010-7","2010-8",
+                                        "2010-9", "2010-10","2010-11","2010-12",
+                                        
+                                        
+                                        "2011-1", "2011-2","2011-3","2011-4",
+                                        "2011-5", "2011-6","2011-7","2011-8",
+                                        "2011-9", "2011-10","2011-11","2011-12",
+                                        "2012-1", "2012-2","2012-3","2012-4",
+                                        "2012-5", "2012-6","2012-7","2012-8",
+                                        "2012-9", "2012-10","2012-11","2012-12",
+                                        "2013-1", "2013-2","2013-3","2013-4",
+                                        "2013-5", "2013-6","2013-7","2013-8",
+                                        "2013-9", "2013-10","2013-11","2013-12",
+                                        "2014-1", "2014-2","2014-3","2014-4",
+                                        "2014-5", "2014-6","2014-7","2014-8",
+                                        "2014-9", "2014-10","2014-11","2014-12",
+                                        "2015-1", "2015-2","2015-3","2015-4",
+                                        "2015-5", "2015-6","2015-7","2015-8",
+                                        "2015-9", "2015-10","2015-11","2015-12",
+                                        "2016-1", "2016-2","2016-3","2016-4",
+                                        "2016-5", "2016-6","2016-7","2016-8",
+                                        "2016-9", "2016-10","2016-11","2016-12"
+                                        )
+                             ),
+         date_YrQtr = factor(paste(date_yr_CLEAN,
+                                   quarter_clean,
+                                   sep = "-"
+                                   ),
+                             levels = c("2006-q1", "2006-q2","2006-q3","2006-q4",
+                                        "2007-q1", "2007-q2","2007-q3","2007-q4",
+                                        "2008-q1", "2008-q2","2008-q3","2008-q4",
+                                        "2009-q1", "2009-q2","2009-q3","2009-q4",
+                                        "2010-q1", "2010-q2","2010-q3","2010-q4",
+                                        
+                                        "2011-q1", "2011-q2","2011-q3","2011-q4",
+                                        "2012-q1", "2012-q2","2012-q3","2012-q4",
+                                        "2013-q1", "2013-q2","2013-q3","2013-q4",
+                                        "2014-q1", "2014-q2","2014-q3","2014-q4",
+                                        "2015-q1", "2015-q2","2015-q3","2015-q4",
+                                        "2016-q1", "2016-q2","2016-q3","2016-q4"
+                                        )
+                             )
+         )
+
+
+# rm(DateClean)
+
+message("DateClean_SelectedVars")
+str(DateClean_SelectedVars)
+
+head(DateClean_SelectedVars, 500)
+tail(DateClean_SelectedVars, 500)
+
+```
+  
+    
+    To adjust `amount` for inflation, we first need the inflation data from the Bureau of Labor Statistics.
+```{r}
+
+# CUUR0000SA0 is the BLS code for monthly CPI data (for the entire US and for all products)
+payload <- list("seriesid" = "CUUR0000SA0",
+                "startyear" = "2010",
+                "endyear" = "2017"
+                )
+BlsCpiRaw_List <- blsAPI(payload) %>% 
+  fromJSON(.)
+
+str(BlsCpiRaw_List)
+
+BlsCpiRaw_List$status
+BlsCpiRaw_List$responseTime
+BlsCpiRaw_List$message
+BlsCpiRaw_List$Results
+
+
+BlsCpiRaw_Tbl <- map_df(BlsCpiRaw_List$Results$series[[1]]$data,
+                        extract,
+                        c("year", "period", "periodName", "value")
+                        ) %>% 
+  mutate(period_num = substr(period, 2, 3) %>% 
+           as.integer()
+         ) %>% 
+  mutate_at(vars("year"), funs(as.integer)
+            ) %>% 
+  mutate_at(vars("value"), funs(as.numeric)
+            ) %>% 
+  mutate(date_YrMth = paste0(as.character(year), "-", as.character(period_num)
+                             ) %>% 
+           as.factor()
+         ) %>% 
+  rename(CPIValue = value) %>% 
+  arrange(year, period_num)
+
+rm(payload, BlsCpiRaw_List)
+
+str(BlsCpiRaw_Tbl)
+BlsCpiRaw_Tbl
+
+```
+  
+    
+    Now we can join to `DateClean_SelectedVars` and calculate the inflation-adjusted amount.
+```{r}
+
+str(DateClean_SelectedVars)
+str(BlsCpiRaw_Tbl)
+
+CPIValue_201706_val <- filter(BlsCpiRaw_Tbl,
+                              year == 2017 &
+                                periodName == "June"
+                              )$CPIValue
+
+DateClean_CPI <- left_join(DateClean_SelectedVars,
+                           select(BlsCpiRaw_Tbl,
+                                  date_YrMth,
+                                  CPIValue
+                                  ),
+                           by = c("date_YrMth", "date_YrMth")
+                           ) %>% 
+  mutate(CPIValue_201706 = CPIValue_201706_val,
+         amount_201706_dollars = round(amount * CPIValue_201706 / CPIValue,
+                                       digits = 2
+                                       )
+         ) %>% 
+  mutate_at(vars(date_YrMth),
+            funs(as.factor)
+            )
+
+
+rm(DateClean_SelectedVars, BlsCpiRaw_Tbl, CPIValue_201706_val)
+
+str(DateClean_CPI)
+head(DateClean_CPI, 500)
+
+```
+  
+    
+    Save the output dataset `DateClean_CPI`
+```{r}
+
+saveRDS(DateClean_CPI, paste0(wd,
+                              "/ProcessedData/",
+                              "DateClean_CPI.Rds"
+                              )
+        )
+
+```
+  
+  
+    Remove unneeded files.
+```{r}
+
+rm(DateClean)
+
+```
+
+


### PR DESCRIPTION
An R Notebook that creates an inflation-adjusted amount variable. This is done using the original `amount` variable, and a Consumer Price Index adjustment (using data from the Bureau of Labor Statistics).

The output dataset contains both the original `amount` variable, and the `amount_201706_dollars` variable which converts the original amount to the equivalent dollars in June 2017.  This make comparison and summary statistics involving `amount_201706_dollars` more accurate.